### PR TITLE
Feature/valid filename

### DIFF
--- a/s3upload/fields.py
+++ b/s3upload/fields.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.db.models import Field
+from django.utils.text import get_valid_filename
 
 from .widgets import S3UploadWidget
 from .utils import remove_signature, get_path_from_url
@@ -34,7 +35,7 @@ class S3UploadField(Field):
                 'bucket', settings.AWS_STORAGE_BUCKET_NAME
             )
             path = get_path_from_url(no_signature_url, bucket_name=bucket_name)
-            return path
+            return get_valid_filename(path)
 
         return file_url
 

--- a/s3upload/utils.py
+++ b/s3upload/utils.py
@@ -12,10 +12,6 @@ from urllib.parse import urlparse, unquote, parse_qs, urlencode
 from django.conf import settings
 
 
-class KeyNotFoundException(Exception):
-    pass
-
-
 def get_at(index, t):
     try:
         value = t[index]
@@ -197,12 +193,7 @@ def get_signed_download_url(
 
     bucket = conn.get_bucket(bucket_name)
     k = Key(bucket)
-
-    try:
-        k.key = key
-    except AttributeError:
-        # key has no 'name' because it's not present in the bucket
-        raise KeyNotFoundException
+    k.key = key
 
     download_url = k.generate_url(
         expires_in=ttl,


### PR DESCRIPTION
This feature uses the get_valid_filename function to bring the path stored by by the component into line with Django FileField.

This feature also removes the redundant KeyNotFoundException (there is no check on whether the key exists in the new logic).