### PR TITLE
Hotfix/valid filename

### DIFF
--- a/s3upload/fields.py
+++ b/s3upload/fields.py
@@ -1,6 +1,5 @@
 from django.conf import settings
 from django.db.models import Field
-from django.utils.text import get_valid_filename
 
 from .widgets import S3UploadWidget
 from .utils import remove_signature, get_path_from_url
@@ -35,7 +34,7 @@ class S3UploadField(Field):
                 'bucket', settings.AWS_STORAGE_BUCKET_NAME
             )
             path = get_path_from_url(no_signature_url, bucket_name=bucket_name)
-            return get_valid_filename(path)
+            return path
 
         return file_url
 

--- a/s3upload/tests.py
+++ b/s3upload/tests.py
@@ -31,7 +31,7 @@ FOO_RESPONSE = {
     u'form_action': u'https://s3.amazonaws.com/{}'.format(settings.AWS_STORAGE_BUCKET_NAME),
     u'success_action_status': 201,
     u'acl': u'public-read',
-    u'key': u'uploads/imgs/${filename}',
+    u'key': u'uploads/imgs/image.jpg',
     u'content-type': u'image/jpeg'
 }
 


### PR DESCRIPTION
This fix removes the filename conversion on the pre-save function and adds it to get_upload_params view function.

This is because the filename conversion on pre-save resulted in malformed paths and should have been at the view level to begin with.

I've tested this version much more throughly than the one submitted yesterday.