### PR TITLE
Add decoding of url to utils path func

### DIFF
--- a/s3upload/tests.py
+++ b/s3upload/tests.py
@@ -189,6 +189,9 @@ class UtilsTest(TestCase):
         test_s3_url_5 = 'https://s3-aws-region.amazonaws.com:443/{0}/folder1/folder2/file1.json'.format(
             settings.AWS_STORAGE_BUCKET_NAME
         )
+        test_s3_url_6 = 'https%3a%2f%2fs3-aws-region.amazonaws.com%3a443%2f{0}%2ffolder1%2ffolder2%2ffile1.json'.format(
+            settings.AWS_STORAGE_BUCKET_NAME
+        )
 
         test_1 = get_s3_path_from_url(test_s3_url_1)
         self.assertEqual(test_1, path)
@@ -204,3 +207,6 @@ class UtilsTest(TestCase):
 
         test_5 = get_s3_path_from_url(test_s3_url_5)
         self.assertEqual(test_5, path)
+
+        test_6 = get_s3_path_from_url(test_s3_url_6)
+        self.assertEqual(test_6, path)

--- a/s3upload/utils.py
+++ b/s3upload/utils.py
@@ -165,7 +165,8 @@ def create_upload_data(content_type, key, acl, bucket=None, cache_control=None,
 
 
 def get_s3_path_from_url(url, bucket_name=settings.AWS_STORAGE_BUCKET_NAME):
-    path = urlparse(url).path
+    decoded = unquote(url)
+    path = urlparse(decoded).path
     # The bucket name might be part of the path,
     # so get the path that comes after the bucket name
     return path.split(bucket_name)[-1]


### PR DESCRIPTION
Based on stored live data, there seems to be some circumstances (that I can't replicate) where the file path is stored URL encoded in the form variable by the client. This causes the field pre-save logic to store the encoded value in the DB which we want to avoid.

This fix uses the 'unquote' function to decode the incoming URL, hopefully eliminating the issue with stored encoded values. I have also updated the unit test of the 'get_s3_path_from_url' function to include URL encoded test data.