### PR TITLE
Fix render when value includes the bucket name already

### DIFF
--- a/s3upload/widgets.py
+++ b/s3upload/widgets.py
@@ -47,7 +47,9 @@ class S3UploadWidget(widgets.TextInput):
                     bucket_name,
                 )
             else:
-                # Default to virtual-hosted–style URL
+                if value.startswith(bucket_name + '/'):
+                    value = value[len(bucket_name + '/'):]
+                # Default to virtual-hosted-bucket URL
                 return "https://{0}.s3.amazonaws.com/{1}".format(bucket_name, value)
         else:
             return ''


### PR DESCRIPTION
When using the admin, the `value` in `render` already has the bucket name, leading to URLs like `<bucket_name>..s3.amazonaws.com/<bucket_name>/...` which do not exist.

The fix removes the bucket name if `value` starts with it.