### PR TITLE
Сustom bucket endpoint url

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,10 @@ AWS_STORAGE_BUCKET_NAME = ''
 # http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
 S3UPLOAD_REGION = 'us-east-1'
 
-# Custom bucket endpoint url (optional)
-# S3UPLOAD_BUCKET_ENDPOINT_URL = 'https://non-amazon-s3-url.com/bucket-name'
+# [Optional] Custom bucket endpoint url, with following keys (also optional):
+# region - region of your bucket
+# bucket - your bucket name
+# S3UPLOAD_BUCKET_ENDPOINT = 'https://{region}.non-amazon-s3-url.com/{bucket}'
 
 # Destinations, with the following keys:
 #

--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ AWS_STORAGE_BUCKET_NAME = ''
 # http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
 S3UPLOAD_REGION = 'us-east-1'
 
+# Custom bucket endpoint url (optional)
+# S3UPLOAD_BUCKET_ENDPOINT_URL = 'https://non-amazon-s3-url.com/bucket-name'
+
 # Destinations, with the following keys:
 #
 # key [required] Where to upload the file to, can be either:

--- a/s3upload/utils.py
+++ b/s3upload/utils.py
@@ -32,7 +32,8 @@ def create_upload_data(  # noqa: C901
     # see https://docs.aws.amazon.com/AmazonS3/latest/dev/\
     #   UsingBucket.html#access-bucket-intro
     # virtual host style endpoints are now the default.
-    bucket_url = getattr(settings, "S3UPLOAD_BUCKET_ENDPOINT_URL", f"https://{bucket}.s3.{region}.amazonaws.com")
+    bucket_endpoint = getattr(settings, "S3UPLOAD_BUCKET_ENDPOINT", "https://{bucket}.s3.{region}.amazonaws.com")
+    bucket_url = bucket_endpoint.format(bucket=bucket, region=region)
     expires_in = datetime.utcnow() + timedelta(seconds=60 * 5)
     expires = expires_in.strftime("%Y-%m-%dT%H:%M:%S.000Z")
     now_date = datetime.utcnow().strftime("%Y%m%dT%H%M%S000Z")

--- a/s3upload/utils.py
+++ b/s3upload/utils.py
@@ -32,7 +32,11 @@ def create_upload_data(  # noqa: C901
     # see https://docs.aws.amazon.com/AmazonS3/latest/dev/\
     #   UsingBucket.html#access-bucket-intro
     # virtual host style endpoints are now the default.
-    bucket_endpoint = getattr(settings, "S3UPLOAD_BUCKET_ENDPOINT", "https://{bucket}.s3.{region}.amazonaws.com")
+    bucket_endpoint = getattr(
+        settings,
+        "S3UPLOAD_BUCKET_ENDPOINT",
+        "https://{bucket}.s3.{region}.amazonaws.com",
+    )
     bucket_url = bucket_endpoint.format(bucket=bucket, region=region)
     expires_in = datetime.utcnow() + timedelta(seconds=60 * 5)
     expires = expires_in.strftime("%Y-%m-%dT%H:%M:%S.000Z")

--- a/s3upload/utils.py
+++ b/s3upload/utils.py
@@ -32,8 +32,7 @@ def create_upload_data(  # noqa: C901
     # see https://docs.aws.amazon.com/AmazonS3/latest/dev/\
     #   UsingBucket.html#access-bucket-intro
     # virtual host style endpoints are now the default.
-    bucket_url = f"https://{bucket}.s3.{region}.amazonaws.com"
-
+    bucket_url = getattr(settings, "S3UPLOAD_BUCKET_ENDPOINT_URL", f"https://{bucket}.s3.{region}.amazonaws.com")
     expires_in = datetime.utcnow() + timedelta(seconds=60 * 5)
     expires = expires_in.strftime("%Y-%m-%dT%H:%M:%S.000Z")
     now_date = datetime.utcnow().strftime("%Y%m%dT%H%M%S000Z")

--- a/s3upload/views.py
+++ b/s3upload/views.py
@@ -78,7 +78,7 @@ def get_upload_params(request: HttpRequest) -> JsonResponse:  # noqa: C901
     if acl == "private":
         url = get_signed_download_url(
             key=key.replace("${filename}", filename),
-            bucket_name=bucket or settings.AWS_STORAGE_BUCKET_NAME,
+            bucket_name=bucket,
             ttl=int(5 * 60),  # 5 mins
         )
 

--- a/s3upload/widgets.py
+++ b/s3upload/widgets.py
@@ -45,7 +45,11 @@ class S3UploadWidget(widgets.TextInput):
                 return get_signed_download_url(value, bucket_name)
             else:
                 # Default to virtual-hosted–style URL
-                bucket_endpoint = getattr(settings, 'S3UPLOAD_BUCKET_ENDPOINT', "https://{bucket}.s3.amazonaws.com")
+                bucket_endpoint = getattr(
+                    settings,
+                    "S3UPLOAD_BUCKET_ENDPOINT",
+                    "https://{bucket}.s3.amazonaws.com",
+                )
                 bucket_url = bucket_endpoint.format(bucket=bucket_name)
                 return "{}/{}".format(bucket_url, value)
         else:

--- a/s3upload/widgets.py
+++ b/s3upload/widgets.py
@@ -45,7 +45,9 @@ class S3UploadWidget(widgets.TextInput):
                 return get_signed_download_url(value, bucket_name)
             else:
                 # Default to virtual-hosted–style URL
-                return "https://{}.s3.amazonaws.com/{}".format(bucket_name, value)
+                bucket_endpoint = getattr(settings, 'S3UPLOAD_BUCKET_ENDPOINT', "https://{bucket}.s3.amazonaws.com")
+                bucket_url = bucket_endpoint.format(bucket=bucket_name)
+                return "{}/{}".format(bucket_url, value)
         else:
             return ""
 

--- a/s3upload/widgets.py
+++ b/s3upload/widgets.py
@@ -11,7 +11,11 @@ from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.safestring import mark_safe
 
-from .utils import get_s3_path_from_url, get_signed_download_url
+from .utils import (
+    get_bucket_endpoint_url,
+    get_s3_path_from_url,
+    get_signed_download_url,
+)
 
 
 class S3UploadWidget(widgets.TextInput):
@@ -38,19 +42,12 @@ class S3UploadWidget(widgets.TextInput):
 
     def get_file_url(self, value: str) -> str:
         if value:
-            bucket_name = settings.S3UPLOAD_DESTINATIONS[self.dest].get(
-                "bucket", settings.AWS_STORAGE_BUCKET_NAME
-            )
+            bucket_name = settings.S3UPLOAD_DESTINATIONS[self.dest].get("bucket")
             if self.acl == "private":
                 return get_signed_download_url(value, bucket_name)
             else:
                 # Default to virtual-hosted–style URL
-                bucket_endpoint = getattr(
-                    settings,
-                    "S3UPLOAD_BUCKET_ENDPOINT",
-                    "https://{bucket}.s3.amazonaws.com",
-                )
-                bucket_url = bucket_endpoint.format(bucket=bucket_name)
+                bucket_url = get_bucket_endpoint_url(bucket_name)
                 return "{}/{}".format(bucket_url, value)
         else:
             return ""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,10 @@
 import pytest
 
-from s3upload.utils import get_s3_path_from_url
+from s3upload.utils import get_s3_path_from_url, get_bucket_endpoint_url
 
 TEST_BUCKET = "test-bucket-name"
 TEST_KEY = "folder1/folder2/file1.json"
+TEST_REGION = "test-region"
 
 
 @pytest.mark.parametrize(
@@ -19,3 +20,19 @@ TEST_KEY = "folder1/folder2/file1.json"
 )
 def test_get_s3_path_from_url(url: str) -> None:
     assert get_s3_path_from_url(url, bucket_name=TEST_BUCKET) == TEST_KEY
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        (None, f"https://{TEST_BUCKET}.s3.{TEST_REGION}.amazonaws.com"),
+        ("https://{bucket}.s3.{region}.amazonaws.com", f"https://{TEST_BUCKET}.s3.{TEST_REGION}.amazonaws.com"),
+        ("https://s3.{region}.amazonaws.com", f"https://s3.{TEST_REGION}.amazonaws.com"),
+        ("https://{bucket}.s3.amazonaws.com", f"https://{TEST_BUCKET}.s3.amazonaws.com"),
+    ]
+)
+def test_get_bucket_endpoint_url(url: str, expected: str) -> None:
+    kwargs = {}
+    if url:
+        kwargs["default"] = url
+    assert get_bucket_endpoint_url(bucket_name=TEST_BUCKET, region=TEST_REGION, **kwargs) == expected


### PR DESCRIPTION
Hi there!

There a few S3-like services, who also use standard boto3 package.
For example, the Object Storage at Yandex.Cloud (https://cloud.yandex.com/en-ru/services/storage).

I've just add an optional setting `S3UPLOAD_BUCKET_ENDPOINT`. It's enough for third-party storages!

"That's one small change for the library. One giant leap for the django!" 😉