### PR TITLE
Update `get_signed_download_url` to use AWS signature version 4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-s3-upload"
-version = "1.1.0"
+version = "1.1.1"
 description = "Integrates direct client-side uploading to s3 with Django."
 authors = ["YunoJuno <code@yunojuno.com>"]
 license = "MIT"

--- a/s3upload/utils.py
+++ b/s3upload/utils.py
@@ -9,6 +9,7 @@ from typing import Any
 from urllib.parse import unquote, urlparse
 
 import boto3
+from botocore.config import Config
 from django.conf import settings
 
 
@@ -146,6 +147,8 @@ def get_signed_download_url(
         "s3",
         aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
         aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
+        config=Config(signature_version="s3v4"),
+        region_name=settings.S3UPLOAD_REGION,
     )
     download_url = s3.generate_presigned_url(
         "get_object", Params={"Bucket": bucket_name, "Key": key}, ExpiresIn=ttl

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -181,7 +181,8 @@ class WidgetTests(TestCase):
                 "acl": "private",
                 "bucket": "test-bucket",
             }
-        }
+        },
+        S3UPLOAD_REGION="eu-west-1",
     )
     def test_check_signed_url(self) -> None:
         data = {"dest": "misc", "name": "image.jpg", "type": "image/jpeg"}
@@ -191,8 +192,8 @@ class WidgetTests(TestCase):
         parsed_qs = parse_qs(parsed_url.query)
         self.assertEqual(parsed_url.scheme, "https")
         self.assertEqual(parsed_url.netloc, "test-bucket.s3.amazonaws.com")
-        self.assertTrue("Signature" in parsed_qs)
-        self.assertTrue("Expires" in parsed_qs)
+        self.assertTrue("X-Amz-Signature" in parsed_qs)
+        self.assertTrue("X-Amz-Expires" in parsed_qs)
 
     def test_content_length_range(self) -> None:
         # Content_length_range setting is always sent as part of policy.


### PR DESCRIPTION
This PR updated the S3 client instantiation inside `get_signed_download_url` function in order to use AWS signature version 4. This is necessary in order to upload files to buckets encrypted with SSE-KMS, and it won't break uploading of files using different encryption algorithms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches presigned S3 download URLs to Signature V4 with explicit region, updates related tests, and bumps version to 1.1.1.
> 
> - **Backend**:
>   - Update `s3upload/utils.py#get_signed_download_url` to configure `boto3.client` with `Config(signature_version="s3v4")` and `region_name=settings.S3UPLOAD_REGION`.
> - **Tests**:
>   - Modify `tests/test_widgets.py::test_check_signed_url` to expect `X-Amz-Signature` and `X-Amz-Expires` and set `S3UPLOAD_REGION`.
> - **Release**:
>   - Bump `pyproject.toml` version from `1.1.0` to `1.1.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f95fa578b3b9e4eb2dd0a9c9b464b41149ecf50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->