### PR TITLE
Add Django 6.0, Python 3.13 support

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -60,14 +60,8 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python: ["3.10", "3.11", "3.12"]
-                # build LTS version, next version, HEAD
-                django: ["42", "50", "51", "52", "main"]
-                exclude:
-                    - python: "3.10"
-                      django: "main"
-                    - python: "3.11"
-                      django: "main"
+                python: ["3.12", "3.13"]
+                django: ["52", "60", "main"]
 
         env:
             TOXENV: django${{ matrix.django }}-py${{ matrix.python }}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Compatibility
 
-This library supports Python 3.10+ and Django 4.2+ only.
+This library supports Python 3.12+ and Django 5.2-6.0.
 
 [![Build Status](https://travis-ci.org/yunojuno/django-s3upload.svg?branch=master)](https://travis-ci.org/yunojuno/django-s3upload)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-s3-upload"
-version = "1.1.1"
+version = "1.2.0"
 description = "Integrates direct client-side uploading to s3 with Django."
 authors = ["YunoJuno <code@yunojuno.com>"]
 license = "MIT"
@@ -12,22 +12,19 @@ documentation = "https://github.com/yunojuno/django-s3-upload"
 classifiers = [
     "Environment :: Web Environment",
     "Framework :: Django",
-    "Framework :: Django :: 4.2",
-    "Framework :: Django :: 5.0",
-    "Framework :: Django :: 5.1",
     "Framework :: Django :: 5.2",
+    "Framework :: Django :: 6.0",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 packages = [{ include = "s3upload" }]
 
 [tool.poetry.dependencies]
-python = "^3.10"
-django = "^4.2 || ^5.0"
+python = "^3.12"
+django = ">=5.2,<7.0"
 boto3 = "^1.14"
 
 [tool.poetry.group.test.dependencies]

--- a/tox.ini
+++ b/tox.ini
@@ -3,12 +3,9 @@ isolated_build = True
 envlist =
     fmt, lint, mypy,
     django-checks,
-    ; https://docs.djangoproject.com/en/5.2/releases/
-    django42-py{310,311,312}
-    django50-py{310,311,312}
-    django51-py{310,311,312}
-    django52-py{310,311,312}
-    djangomain-py{311,312}
+    django52-py{312,313}
+    django60-py{312,313}
+    djangomain-py{312,313}
 
 [testenv]
 deps =
@@ -16,10 +13,8 @@ deps =
     pytest
     pytest-cov
     pytest-django
-    django42: Django>=4.2,<4.3
-    django50: Django>=5.0,<5.1
-    django51: Django>=5.1,<5.2
     django52: Django>=5.2,<5.3
+    django60: Django>=6.0,<6.1
     djangomain: https://github.com/django/django/archive/main.tar.gz
 
 commands =


### PR DESCRIPTION
## Summary

This PR upgrades the package to support Django 6.0 and Python 3.13.

## Changes

### Added
  - ✅ Django 6.0 support
  - ✅ Python 3.12, 3.13 support

### Removed
  - ❌ Python 3.9, 3.10, 3.11 support (now requires Python 3.12+)
  - ❌ Django 4.2 and 5.0 support (now supports Django 5.2-6.0)