### PR TITLE
Add content_disposition param to get_signed_download_url

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -63,9 +63,6 @@ jobs:
                 python: ["3.12", "3.13"]
                 django: ["52", "60", "main"]
 
-        env:
-            TOXENV: django${{ matrix.django }}-py${{ matrix.python }}
-
         steps:
             - name: Check out the repository
               uses: actions/checkout@v4
@@ -74,6 +71,9 @@ jobs:
               uses: actions/setup-python@v4
               with:
                   python-version: ${{ matrix.python }}
+
+            - name: Set TOXENV
+              run: echo "TOXENV=django${{ matrix.django }}-py$(echo '${{ matrix.python }}' | tr -d '.')" >> $GITHUB_ENV
 
             - name: Install and run tox
               run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-s3-upload"
-version = "1.2.0"
+version = "1.3.0"
 description = "Integrates direct client-side uploading to s3 with Django."
 authors = ["YunoJuno <code@yunojuno.com>"]
 license = "MIT"

--- a/s3upload/utils.py
+++ b/s3upload/utils.py
@@ -141,6 +141,7 @@ def get_signed_download_url(
     key: str,
     bucket_name: str | None = None,
     ttl: int = 60,
+    content_disposition: str | None = None,
 ) -> str:
     bucket_name = bucket_name or settings.AWS_STORAGE_BUCKET_NAME
     s3 = boto3.client(
@@ -150,8 +151,11 @@ def get_signed_download_url(
         config=Config(signature_version="s3v4"),
         region_name=settings.S3UPLOAD_REGION,
     )
+    params: dict[str, str] = {"Bucket": bucket_name, "Key": key}
+    if content_disposition:
+        params["ResponseContentDisposition"] = content_disposition
     download_url = s3.generate_presigned_url(
-        "get_object", Params={"Bucket": bucket_name, "Key": key}, ExpiresIn=ttl
+        "get_object", Params=params, ExpiresIn=ttl
     )
     return download_url
 

--- a/s3upload/utils.py
+++ b/s3upload/utils.py
@@ -141,6 +141,7 @@ def get_signed_download_url(
     key: str,
     bucket_name: str | None = None,
     ttl: int = 60,
+    *,
     content_disposition: str | None = None,
 ) -> str:
     bucket_name = bucket_name or settings.AWS_STORAGE_BUCKET_NAME

--- a/s3upload/utils.py
+++ b/s3upload/utils.py
@@ -154,9 +154,7 @@ def get_signed_download_url(
     params: dict[str, str] = {"Bucket": bucket_name, "Key": key}
     if content_disposition:
         params["ResponseContentDisposition"] = content_disposition
-    download_url = s3.generate_presigned_url(
-        "get_object", Params=params, ExpiresIn=ttl
-    )
+    download_url = s3.generate_presigned_url("get_object", Params=params, ExpiresIn=ttl)
     return download_url
 
 


### PR DESCRIPTION
## Summary

Adds an optional `content_disposition` parameter to `get_signed_download_url` that passes `ResponseContentDisposition` to the S3 presigned URL. This allows callers to control whether the browser downloads a file (`attachment`) or displays it inline (`inline`), without needing to change the stored S3 object metadata.

## Why is this change being made?

Currently there is no way to override the Content-Disposition behaviour when generating presigned download URLs. This is needed to support opening PDFs (e.g. invoices) directly in the browser tab instead of forcing a download.

## Steps to test the change?

1. Call `get_signed_download_url(key="some-pdf-key", content_disposition="inline")`
2. Verify the returned presigned URL contains `ResponseContentDisposition=inline`
3. Verify existing callers without `content_disposition` continue to work as before

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backward-compatible optional keyword on presigned URL generation; no auth or data-model changes.
> 
> **Overview**
> **Adds optional `content_disposition` on `get_signed_download_url`** so presigned GET URLs can set S3 `ResponseContentDisposition` (e.g. `inline` for in-browser PDFs vs default download behavior). Existing call sites stay the same when the argument is omitted.
> 
> Also **bumps the package to 1.3.0** and **fixes CI `TOXENV` naming** in the test matrix by stripping dots from the Python version (e.g. `py312`) instead of embedding `3.12` in the env name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f3ddd5838db9920965b5c0d6f64c37a4b5b5a14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->